### PR TITLE
Revert "Update"

### DIFF
--- a/charts/backstage/backstage-rhtap-values.yaml
+++ b/charts/backstage/backstage-rhtap-values.yaml
@@ -49,12 +49,8 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
         disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-jenkins-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-jenkins
-        disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
-        disabled: false        
+        disabled: false
       - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-tekton
         pluginConfig:
           dynamicPlugins:
@@ -280,13 +276,6 @@ upstream:
         # The UI url for Quay, used to generate the link to Quay
         uiUrl: 'https://{{ ocp4_workload_trusted_application_pipeline_quay_host }}'
 
-      jenkins:
-        instances:
-          - name: default
-            baseUrl: {{ ocp4_workload_trusted_application_pipeline_jenkins_host }}
-            username: admin
-            apiKey: {{ ocp4_workload_trusted_application_pipeline_jenkins_token }}
-
       techdocs:
         builder: 'external'
         generator:
@@ -386,7 +375,7 @@ upstream:
         github: false
         githubOrg: false
         gitlab: true
-        jenkins: true
+        jenkins: false
         permission: false
 
   postgresql:


### PR DESCRIPTION
Reverts redhat-gpe/janus-idp-gitops#10

Caused this issue when activating jenkins - all CI's using this now fail:
TASK [ocp4_workload_trusted_application_pipeline : Apply template ~ec2-user/janus-idp-gitops/charts/backstage/backstage-rhtap-values.yaml] ***
Wednesday 04 December 2024  17:31:47 +0000 (0:00:00.497)       1:29:55.280 **** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'ocp4_workload_trusted_application_pipeline_jenkins_host' is undefined. 'ocp4_workload_trusted_application_pipeline_jenkins_host' is undefined
fatal: [bastion.r64qs.internal]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'ocp4_workload_trusted_application_pipeline_jenkins_host' is undefined. 'ocp4_workload_trusted_application_pipeline_jenkins_host' is undefined"}